### PR TITLE
Add VS Code to the IDE list

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ See also:
 - ★ [Sublime Text](http://www.sublimetext.com) — one of the best text editors for coding. Take a look at [Sublime Bookmarks](https://github.com/dreikanter/sublime-bookmarks) — a comprehensive list of plugins and other related stuff.
 - [RubyMine](http://jetbrains.com/ruby/) — intelligent Ruby and Rails IDE.
 - [Atom](http://atom.io) — a brand-new hackable text editor from Github.
+- [Visual Studio Code](code.visualstudio.com) — Redefined code editor from Microsoft with [Ruby debugging support](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby).
 
 ### Code quality analysis
 


### PR DESCRIPTION
As VS Code allows to customize its debugging interface, we can debug ruby the same way as RubyMine with extensions.