### PR TITLE
Removed Smarterer

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,6 @@ See also:
 
 - [codequizzes.com](http://codequizzes.com) — learn programming by doing, not by reading.
 - [codewars.com](http://www.codewars.com) — achieve mastery through challenge.
-- [Smarterer.com](http://smarterer.com/home) — crowdsourced tests for Ruby, Rails, and a lot of other technologies.
 - [oDesk](https://www.odesk.com/tests) — a global freelance platform that includes qualification testing for programming languages and frameworks.
 
 ## Hosting


### PR DESCRIPTION
In 2014, [Pluralsight acquired Smarterer](http://smarterer.com/home). Although they still do have many [assessments](https://app.pluralsight.com/score), they don’t have Ruby nor Ruby on Rails assessments anymore.