### PR TITLE
Updated links for Ruby one-liners cookbook & Ruby Regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Rails or databases previously. Good for beginners.
 - [Jumpstart Lab](http://tutorials.jumpstartlab.com/) — a list of beginner and advanced-level Ruby, Rails, and Sinatra project tutorials.  Includes challenging independent projects as well.
 - [RubyOffRails](https://rubyoffrails.com/) — An online Ruby course recently open sourced.
 - [The Odin Project](http://www.theodinproject.com/ruby-programming) — an online Ruby lesson plan with a community to help.
-- [Ruby one liners](https://github.com/learnbyexample/Command-line-text-processing/blob/master/ruby_one_liners.md) (a page from Command Line Text Processing project).
-- [Ruby Regexp](https://leanpub.com/rubyregexp) — free ebook to learn Ruby regular expressions, includes exercises.
+- [Ruby one-liners cookbook](https://learnbyexample.github.io/learn_ruby_oneliners/preface.html) — free guide for text processing with Ruby from the command line.
+- [Ruby Regexp](https://learnbyexample.github.io/Ruby_Regexp/preface.html) — free ebook to learn Ruby regular expressions, includes exercises.
 
 ## Style Guides
 


### PR DESCRIPTION
Changed links for my ebooks:

* Ruby one-liners cookbook — updated to the modified web book with more examples and exercises
* Ruby Regexp — now points to the online web book version